### PR TITLE
Add rTokenAuthentication to authentication strategies tuple

### DIFF
--- a/djackets_django/settings.py
+++ b/djackets_django/settings.py
@@ -113,6 +113,12 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.TokenAuthentication',
+    ),
+}
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.1/topics/i18n/


### PR DESCRIPTION
Add ``rest_framework.authentication.TokenAuthentication`` to Django REST Framework authentication strategies tuple.

Because without it, the ``/api/v1/token/login`` endpoint cannot work!

Then, run ``python manage.py makemigrations`` and ``python manage.py migrate``, this will create ``auth`` and ``authtoken`` tables.

After creating ``auth`` and ``authtoken`` tables, you should be able to create a user and get token from the ``/api/v1/token/login`` endpoint.